### PR TITLE
Test PR with invalid backport label [test-label-validation-1755263415-140535721551232-1944159-9435]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,8 @@
 # Testing file
 
 This file contains random data, used for PR testing.
+
+
+## Test Invalid Backport 1755263421
+
+Testing workflow failure with invalid backport label.


### PR DESCRIPTION

This PR tests workflow failure with invalid backport value.

```yaml
release: 1.0                    # This is valid
backport: invalid-backport      # This should cause workflow to fail
```

The workflow should fail because 'invalid-backport' is not in the accepted
backports list.
