### PR TITLE
Test PR with invalid release label [test-repo-1755267076-140424056632704-1999553-1482]

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,8 @@
 # Testing file
 
 This file contains random data, used for PR testing.
+
+
+## Test Invalid Release 1755267087
+
+Testing workflow failure with invalid release label.


### PR DESCRIPTION

This PR tests workflow failure with invalid release value.

```yaml
release: invalid-version  # This should cause workflow to fail
backport: 1.0            # This is valid
```

The workflow should fail because 'invalid-version' is not in the accepted releases list.
