### PR TITLE
Test Feature Branch Labeling (invalid) [fork-1757126617-140066368415168]

### DIFF
--- a/test_changes.md
+++ b/test_changes.md
@@ -1,0 +1,3 @@
+# Test changes for Test Feature Branch Labeling (invalid)
+
+Timestamp: 1757126619.757373


### PR DESCRIPTION
This PR tests feature branch labeling with invalid needs_feature_branch value.

```yaml
needs_feature_branch: maybe
```

This should cause the workflow to fail.