### PR TITLE
Test validation error comment lifecycle (create + auto-remove) [fork-1757126914-140066368415168]

### DIFF
--- a/test_changes.md
+++ b/test_changes.md
@@ -1,0 +1,3 @@
+# Test changes for Test validation error comment lifecycle (create + auto-remove)
+
+Timestamp: 1757126917.4015868


### PR DESCRIPTION
This PR tests the complete lifecycle of validation error comments.

```yaml
needs_feature_branch: maybe_invalid_value  # Invalid value not in accepted list (true/false)
```

The value above is not in the accepted list and should create a validation error comment.