### PR TITLE
Test PR with invalid release label [fork-1757127147-140066368415168]

### DIFF
--- a/test_changes.md
+++ b/test_changes.md
@@ -1,0 +1,3 @@
+# Test changes for Test PR with invalid release label
+
+Timestamp: 1757127150.3048978


### PR DESCRIPTION

This PR tests workflow failure with invalid release value.

```yaml
release: invalid-version  # This should cause workflow to fail
backport: 1.0            # This is valid
```

The workflow should fail because 'invalid-version' is not in the accepted releases list.
