### PR TITLE
Test validation error comment lifecycle (create + auto-remove) [fork-1757128070-140066368415168]

### DIFF
--- a/test_changes.md
+++ b/test_changes.md
@@ -1,0 +1,3 @@
+# Test changes for Test validation error comment lifecycle (create + auto-remove)
+
+Timestamp: 1757128072.9338288


### PR DESCRIPTION
This PR tests that validation error comments are auto-deleted when YAML is fixed.

```yaml
release: 1.0  # Valid release version
backport: 1.1  # Valid backport target
```

The tags above are now valid and should cause the error comment to be automatically deleted.